### PR TITLE
Integrate Qt callbacks and remove console code

### DIFF
--- a/monopoly/Game/Board.cpp
+++ b/monopoly/Game/Board.cpp
@@ -109,9 +109,5 @@ void Board::updateProperty(const std::vector<std::shared_ptr<Player>>& players) 
 }
 
 void Board::clearScreen() {
-#ifdef _WIN32
-    system("cls");
-#else
-    std::cout << "\033[2J\033[H"; // ANSI Escape Code to clear the screen and move the cursor to the top-left corner
-#endif
+    // Deprecated: clearing the terminal is no longer needed when using a GUI
 }

--- a/monopoly/Game/Game.cpp
+++ b/monopoly/Game/Game.cpp
@@ -15,6 +15,8 @@
 
 std::default_random_engine Game::engine;
 std::shared_ptr<Game> Game::instance = nullptr;
+Game::InfoCallback Game::infoCallback = nullptr;
+Game::PromptCallback Game::promptCallback = nullptr;
 
 Game::Game(const GameConfig& cfg)
     : config(cfg), currentState(State::INIT), gameForceControl(false) {
@@ -71,7 +73,7 @@ void Game::nextTurn() {
     playersList[currentTurnIndex]->setMyTurn(true);
     changeState(State::START);
 
-    std::cout << "🕐 Next turn: " << playersList[currentTurnIndex]->getName() << "\n";
+    log("\xF0\x9F\x95\x90 Next turn: " + playersList[currentTurnIndex]->getName());
 }
 
 void Game::executeSudoCommand(const ParsedCommand& cmd){
@@ -155,7 +157,7 @@ void Game::initGame() {
     Board::getInstance()->init(config, playersList);
 
     changeState(State::INIT);
-    std::cout << "[INIT] Game initialized with " << playersList.size() << " players.\n";
+    log("[INIT] Game initialized with " + std::to_string(playersList.size()) + " players.");
 }
 
 void Game::start() {
@@ -171,12 +173,12 @@ void Game::start() {
     }
 
     // Optional: log or show a start message
-    std::cout << "🎮 Game started. It's " << playersList[currentTurnIndex]->getName() << "'s turn.\n";
+    log("\xF0\x9F\x8E\xAE Game started. It's " + playersList[currentTurnIndex]->getName() + "'s turn.");
 }
 
 void Game::processPlayerAction(std::shared_ptr<Player> player, std::shared_ptr<Tile> tile, bool isCommandResult) {
     if (tile->isBlocked()) {
-        std::cout << "This tile is blocked by a barrier. Skipping turn...\n";
+        log("This tile is blocked by a barrier. Skipping turn...");
         nextTurn();
         return;
     }
@@ -216,48 +218,24 @@ void Game::processPlayerAction(std::shared_ptr<Player> player, std::shared_ptr<T
     }
 
     std::string prompt = optionsJson["prompt"];
-    std::cout << prompt << "\n";
-
     const auto& options = optionsJson["options"];
-    for (const auto& opt : options) {
-        std::cout << "[" << opt["key"] << "] " << opt["description"] << "\n";
-    }
 
-    std::string input;
-    while (true) {
-        std::cout << "> ";
-        std::getline(std::cin, input);
-
-        bool matched = false;
-        // TODO: 這邊要想一下，因為我們用UI的話，這邊應該不會有輸入
-        for (const auto& opt : options) {
-            if (opt["key"] == "*" || opt["key"] == input) {
-                matched = true;
-                if (input == "I") {
-                    //player->printInfo();
-                } else if (input == "R") {
-                    // Buy or upgrade
-                    // Placeholder: handle accordingly
-                } else if (input == "S") {
-                    // Sell
-                    // Placeholder: handle accordingly
-                } else if (input == "E") {
-                    // Enter store
-                    // Placeholder
-                } else if (input == "T") {
-                    // Roll dice (usually not here)
+    if (promptCallback) {
+        promptCallback(prompt, options, [this, options](const std::string& input) {
+            bool matched = false;
+            for (const auto& opt : options) {
+                if (opt["key"] == "*" || opt["key"] == input) {
+                    matched = true;
+                    if (opt["key"] == "*" || input != "I") {
+                        nextTurn();
+                    }
+                    break;
                 }
-                if (opt["key"] == "*" || input != "I") {
-                    nextTurn();
-                    return;
-                }
-                break;
             }
-        }
-
-        if (!matched) {
-            std::cout << dialogueData["invalid_input"]["prompt"] << "\n";
-        }
+            if (!matched) {
+                log(dialogueData["invalid_input"]["prompt"]);
+            }
+        });
     }
 }
 
@@ -290,35 +268,33 @@ void Game::checkGameOver() {
 
     if (aliveCount <= 1) {
         changeState(State::FINISH);
-        std::cout << "\n============================\n";
-        std::cout << "        GAME OVER!\n";
-        std::cout << "============================\n";
+        log("============================\n        GAME OVER!\n============================");
         if (lastAlive) {
-            std::cout << "Winner: " << lastAlive->getName() << " with $" << lastAlive->getMoney() << "\n";
+            log("Winner: " + lastAlive->getName() + " with $" + std::to_string(lastAlive->getMoney()));
         } else {
-            std::cout << "No winner (all players bankrupt).\n";
+            log("No winner (all players bankrupt).");
         }
         endGame();
     }
 }
 
 void Game::endGame() {
-    std::cout << "\nFinal Player Status:\n";
-    std::cout << "---------------------\n";
+    log("\nFinal Player Status:");
+    log("---------------------");
     for (const auto& player : playersList) {
-        std::cout << player->getName() << " - $" << player->getMoney();
+        std::string line = player->getName() + " - $" + std::to_string(player->getMoney());
         if (player->isBankrupt()) {
-            std::cout << " [BANKRUPT]";
+            line += " [BANKRUPT]";
         }
-        std::cout << "\n";
+        log(line);
     }
-    std::cout << "\nThank you for playing Monopoly!\n";
+    log("\nThank you for playing Monopoly!");
 }
 
 void Game::changeState(State newState) {
-    std::cout << "[STATE] Transition: " << getStateString() << " → ";
+    log("[STATE] Transition: " + getStateString() + " → ");
     setState(newState);
-    std::cout << getStateString() << "\n";
+    log(getStateString());
 }
 
 State& operator++(State& state) {
@@ -405,4 +381,20 @@ bool Game::isActivateState() const {
 
 bool Game::isRoundState() const {
     return currentState == State::ROUND_END;
+}
+
+void Game::setInfoCallback(InfoCallback cb) {
+    infoCallback = std::move(cb);
+}
+
+void Game::setPromptCallback(PromptCallback cb) {
+    promptCallback = std::move(cb);
+}
+
+void Game::log(const std::string& message) {
+    if (infoCallback) {
+        infoCallback(message);
+    } else {
+        std::cout << message << std::endl;
+    }
 }

--- a/monopoly/Game/Game.hpp
+++ b/monopoly/Game/Game.hpp
@@ -12,6 +12,7 @@
 #include <memory>
 #include <random>
 #include <vector>
+#include <functional>
 
 enum class State { INIT, START, MOVED, ROUND_END, FINISH };
 State& operator++(State& state);
@@ -30,6 +31,12 @@ private:
 
     std::vector<std::shared_ptr<Player>> players;
     static std::default_random_engine engine;
+
+    using InfoCallback = std::function<void(const std::string&)>;
+    using PromptCallback = std::function<void(const std::string&, const nlohmann::json&, std::function<void(const std::string&)>)>;
+
+    static InfoCallback infoCallback;
+    static PromptCallback promptCallback;
 
     // isCommandResult = false (default). let it continue to retry input when isCommandResult = true
     void processPlayerAction(std::shared_ptr<Player> player, std::shared_ptr<Tile> tile, bool isCommandResult = false);
@@ -57,6 +64,10 @@ public:
     std::string getStateString();
     bool isActivateState() const;
     bool isRoundState() const;
+
+    static void log(const std::string& message);
+    void setInfoCallback(InfoCallback cb);
+    void setPromptCallback(PromptCallback cb);
 };
 
 #endif // GAME_HPP

--- a/monopoly/Game/Player.cpp
+++ b/monopoly/Game/Player.cpp
@@ -94,7 +94,7 @@ bool Player::deductMoney(long long amount) {
     if (money < 0){
         bankrupt = true;
         money = 0;
-        std::cout << "[PLAYER] " << name << " is bankrupt!\n";
+        Game::log("[PLAYER] " + name + " is bankrupt!");
     }
     return true;
 }
@@ -106,19 +106,19 @@ void Player::setBankrupt(bool b) {
 
 void Player::sendToStart() {
     position = 0;
-    std::cout << "[PLAYER] send to start" << std::endl;
+    Game::log("[PLAYER] send to start");
 }
 
 void Player::sendToHospital(int rounds) {
     inHospital = true;
     hospitalRoundLeft = rounds;
-    std::cout << "[PLAYER-HOSPITAL] " << name << " is sent to hospital for " << rounds << " rounds." << std::endl;
+    Game::log("[PLAYER-HOSPITAL] " + name + " is sent to hospital for " + std::to_string(rounds) + " rounds.");
 }
 
 void Player::recoverFromHospital() {
     inHospital = false;
     hospitalRoundLeft = 0;
-    std::cout << "[PLAYER-HOSPITAL] " << name << " has recovered and left the hospital." << std::endl;
+    Game::log("[PLAYER-HOSPITAL] " + name + " has recovered and left the hospital.");
 }
 
 void Player::updateHospitalStatus() {
@@ -126,7 +126,7 @@ void Player::updateHospitalStatus() {
 
     if (hospitalRoundLeft > 0){
         hospitalRoundLeft--;
-        std::cout << "[PLAYER-HOSPITAL] " << name << " has " << hospitalRoundLeft << " rounds left in hospital." << std::endl;
+        Game::log("[PLAYER-HOSPITAL] " + name + " has " + std::to_string(hospitalRoundLeft) + " rounds left in hospital.");
     }
 
     if (hospitalRoundLeft <= 0){
@@ -163,14 +163,14 @@ std::vector<std::shared_ptr<Card>> Player::getCards() {
 void Player::displayCards(std::vector<std::shared_ptr<Player>>& players) {
     for (size_t i = 0; i < cards.size(); i++){
         if (cards[i]){
-            std::cout << i << ". " << cards[i]->getName() << " - " << cards[i]->getEffect() << "\n";
+            Game::log(std::to_string(i) + ". " + cards[i]->getName() + " - " + cards[i]->getEffect());
         }
     };
 }
 
 void Player::useCard(int index, std::vector<std::shared_ptr<Player>>& players) {
     if (index < 0 || index >= static_cast<int>(cards.size())){
-        std::cout << "[PLAYER-CARD] Invalid card index\n";
+        Game::log("[PLAYER-CARD] Invalid card index");
         return;
     };
 
@@ -180,7 +180,7 @@ void Player::useCard(int index, std::vector<std::shared_ptr<Player>>& players) {
     card->useEffect(players, shared_from_this());
     cards.erase(cards.begin()+index);
 
-    std::cout << "[PLAYER-CARD] Card used: " << card->getName() << std::endl;
+    Game::log("[PLAYER-CARD] Card used: " + card->getName());
 }
 
 void Player::setDiceControl(int step) {
@@ -195,7 +195,7 @@ int Player::rollDice() {
     if (diceControl != -1){
         int result = diceControl;
         diceControl = -1;
-        std::cout << "[PLAYER-DICE] Controlled dice result: " << result << std::endl;
+        Game::log("[PLAYER-DICE] Controlled dice result: " + std::to_string(result));
         return result;
     }
 
@@ -204,6 +204,6 @@ int Player::rollDice() {
     static std::uniform_int_distribution<> dist(1, 6);
 
     int result = dist(gen);
-    std::cout << "[PLAYER-DICE] Random roll: " << result << std::endl;
+    Game::log("[PLAYER-DICE] Random roll: " + std::to_string(result));
     return result;
 }

--- a/monopoly/UI/MainWindow.cpp
+++ b/monopoly/UI/MainWindow.cpp
@@ -2,11 +2,13 @@
 #include "CardDialog.hpp"
 #include "MiniGameDialog.hpp"
 #include "SudoDialog.hpp"
+#include "PromptDialog.hpp"
 #include "Game.hpp"
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QPushButton>
 #include <QLabel>
+#include <QMessageBox>
 
 void MainWindow::refresh() {
     auto players = Game::getInstance()->getPlayers();
@@ -43,6 +45,7 @@ void MainWindow::refresh() {
 
 MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent) {
     setupUI();
+    setupCallbacks();
 }
 
 void MainWindow::setupUI() {
@@ -97,5 +100,20 @@ void MainWindow::setupUI() {
             refresh();
         });
         sudo->exec();
+    });
+}
+
+void MainWindow::setupCallbacks() {
+    auto game = Game::getInstance();
+    game->setInfoCallback([this](const std::string& msg) {
+        QMessageBox::information(this, "Info", QString::fromStdString(msg));
+        refresh();
+    });
+    game->setPromptCallback([this](const std::string& prompt, const nlohmann::json& opts, std::function<void(const std::string&)> cb) {
+        PromptDialog dlg(this);
+        dlg.setPrompt(prompt, opts);
+        std::string res = dlg.execAndGetResult();
+        if (cb) cb(res);
+        refresh();
     });
 }

--- a/monopoly/UI/MainWindow.hpp
+++ b/monopoly/UI/MainWindow.hpp
@@ -20,6 +20,7 @@ private:
     PlayerPanel* playerPanel;
 
     void setupUI();
+    void setupCallbacks();
 };
 
 #endif // MAINWINDOW_HPP

--- a/monopoly/UI/PromptDialog.cpp
+++ b/monopoly/UI/PromptDialog.cpp
@@ -1,0 +1,39 @@
+#include "PromptDialog.hpp"
+#include <QVBoxLayout>
+#include <QPushButton>
+#include <QLabel>
+
+PromptDialog::PromptDialog(QWidget* parent)
+    : QDialog(parent), promptLabel(new QLabel(this)), buttonLayout(new QVBoxLayout()) {
+    QVBoxLayout* main = new QVBoxLayout(this);
+    main->addWidget(promptLabel);
+    main->addLayout(buttonLayout);
+    setLayout(main);
+    setWindowTitle("Action Required");
+}
+
+void PromptDialog::setPrompt(const std::string& prompt, const nlohmann::json& options) {
+    promptLabel->setText(QString::fromStdString(prompt));
+
+    QLayoutItem* item;
+    while ((item = buttonLayout->takeAt(0)) != nullptr) {
+        if (item->widget()) item->widget()->deleteLater();
+        delete item;
+    }
+
+    for (const auto& opt : options) {
+        QString text = QString("[%1] %2").arg(QString::fromStdString(opt["key"])).
+                arg(QString::fromStdString(opt["description"]));
+        QPushButton* btn = new QPushButton(text, this);
+        connect(btn, &QPushButton::clicked, this, [this, key=QString::fromStdString(opt["key"])](){
+            result = key;
+            accept();
+        });
+        buttonLayout->addWidget(btn);
+    }
+}
+
+std::string PromptDialog::execAndGetResult() {
+    QDialog::exec();
+    return result.toStdString();
+}

--- a/monopoly/UI/PromptDialog.hpp
+++ b/monopoly/UI/PromptDialog.hpp
@@ -1,0 +1,22 @@
+#ifndef PROMPTDIALOG_HPP
+#define PROMPTDIALOG_HPP
+
+#include <QDialog>
+#include <nlohmann/json.hpp>
+
+class QLabel;
+class QVBoxLayout;
+
+class PromptDialog : public QDialog {
+    Q_OBJECT
+public:
+    explicit PromptDialog(QWidget* parent = nullptr);
+    void setPrompt(const std::string& prompt, const nlohmann::json& options);
+    std::string execAndGetResult();
+private:
+    QLabel* promptLabel;
+    QVBoxLayout* buttonLayout;
+    QString result;
+};
+
+#endif // PROMPTDIALOG_HPP


### PR DESCRIPTION
## Summary
- replace leftover console screen clear logic in `Board`
- introduce callback mechanism in `Game` to replace `std::cout/std::cin`
- adapt `Player` methods to use the callback logger
- add `PromptDialog` and hook callbacks through `MainWindow`

## Testing
- `cmake -B build && cmake --build build -j 4` *(fails: could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_68454af1c0fc832ab993b17a4012bd01